### PR TITLE
Properly document SystemClock conflict

### DIFF
--- a/Multiplayer.json
+++ b/Multiplayer.json
@@ -16,6 +16,7 @@
     "Balatro (>=1.0.1n)"
   ],
 	"conflicts": [
+		"SystemClock (<<1.6.3)",
 		"Cryptid (<=0.5.3c)",
 		"Talisman (<<2.1.0~dev)"
 	]


### PR DESCRIPTION
Previously there existed a bug where SystemClock would cause a disconnect after beating a blind. This has been fixed in SystemClock 1.6.3. This pull request adds a marked conflict for SystemClock <1.6.3.