### PR TITLE
fix(cryptid): disable reboot code card. causes crash when used.

### DIFF
--- a/Compatibility/Cryptid.lua
+++ b/Compatibility/Cryptid.lua
@@ -11,6 +11,7 @@ if SMODS.Mods["Cryptid"] and SMODS.Mods["Cryptid"].can_load then
 	G.MULTIPLAYER.DECK.ban_card("c_cry_crash")
 	G.MULTIPLAYER.DECK.ban_card("c_cry_revert")
 	G.MULTIPLAYER.DECK.ban_card("c_cry_analog")
+	G.MULTIPLAYER.DECK.ban_card("c_cry_reboot")
 	G.MULTIPLAYER.DECK.ban_blind("bl_cry_joke")
 
 	local defeat_ref = Blind.defeat


### PR DESCRIPTION
This card refreshes a players hand. I played it and attempted to use a hand and it crashed the game. I feel Cryptid compatibility is gonna take alot of playing to figure out which cards cause crashes. Will be playing over the next few days and banning anything that causes issues