### PR TITLE
add: 'PVP Starts at Round' gamemode option

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -11,6 +11,7 @@ MP.LOBBY = {
 		death_on_round_loss = true,
 		different_seeds = false,
 		starting_lives = 4,
+		pvp_start_round = 2,
 		showdown_starting_antes = 3,
 		ruleset = "ruleset_mp_standard",
 		custom_seed = "random",

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -224,6 +224,7 @@ return {
 			k_connect_player = "Connected Players:",
 			k_opts_only_host = "Only the Lobby Host can change these options",
 			k_opts_gm = "Gamemode Modifiers",
+			k_opts_pvp_start_round = "PVP Starts at Round",
 			k_bl_life = "Life",
 			k_bl_or = "or",
 			k_bl_death = "Death",

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -184,6 +184,9 @@ local function action_lobby_options(options)
 		if k == "starting_lives" then
 			parsed_v = tonumber(v)
 		end
+		if k == "pvp_start_round" then
+			parsed_v = tonumber(v)
+		end
 		MP.LOBBY.config[k] = parsed_v
 		if G.OVERLAY_MENU then
 			local config_uie = G.OVERLAY_MENU:get_UIE_by_ID(k .. "_toggle")

--- a/ui/game.lua
+++ b/ui/game.lua
@@ -1623,7 +1623,7 @@ local reset_blinds_ref = reset_blinds
 function reset_blinds()
 	reset_blinds_ref()
 	if MP.LOBBY.code then
-		if G.GAME.round_resets.ante > 1 then
+		if G.GAME.round_resets.ante >= MP.LOBBY.config.pvp_start_round then
 			G.GAME.round_resets.blind_choices.Boss = "bl_mp_nemesis"
 		end
 	end

--- a/ui/lobby.lua
+++ b/ui/lobby.lua
@@ -686,6 +686,36 @@ function G.UIDEF.create_UIBox_lobby_options()
 														current_option = MP.LOBBY.config.starting_lives,
 														opt_callback = "change_starting_lives",
 													}),
+													Disableable_Option_Cycle({
+														id = "pvp_round_start_option",
+														enabled_ref_table = MP.LOBBY,
+														enabled_ref_value = "is_host",
+														label = localize("k_opts_pvp_start_round"),
+														options = {
+															1,
+															2,
+															3,
+															4,
+															5,
+															6,
+															7,
+															8,
+															9,
+															10,
+															11,
+															12,
+															13,
+															14,
+															15,
+															16,
+															17,
+															18,
+															19,
+															20,
+														},
+														current_option = MP.LOBBY.config.pvp_start_round,
+														opt_callback = "change_starting_pvp_round",
+													}),
 												},
 											},
 										},
@@ -820,6 +850,11 @@ end
 
 G.FUNCS.change_starting_lives = function(args)
 	MP.LOBBY.config.starting_lives = args.to_val
+	send_lobby_options()
+end
+
+G.FUNCS.change_starting_pvp_round = function(args)
+	MP.LOBBY.config.pvp_start_round = args.to_val
 	send_lobby_options()
 end
 


### PR DESCRIPTION
Ability to change the round in which PVP starts, essentially creating a poor mans showdown except with blinds between.